### PR TITLE
Dev/achilleas eng 2191 feat: Accept multiple labelValues

### DIFF
--- a/cmd/casper-3/main.go
+++ b/cmd/casper-3/main.go
@@ -31,7 +31,7 @@ func main() {
 		logger.Info(msg)
 		return
 	}
-	logger.Info("Launching casper-3", "labelKey", cfg.LabelKey, "labelValue", cfg.LabelValue, "interval", cfg.ScanIntervalSeconds, "environment", cfg.Env, "TXT identifier", fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env))
+	logger.Info("Launching casper-3", "labelKey", cfg.LabelKey, "labelValues", cfg.LabelValues, "interval", cfg.ScanIntervalSeconds, "environment", cfg.Env, "TXT identifier", fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env))
 
 	// Run loop based on interval. Check if there are unlabelled instances.
 	// If there are unlabelled instances, add label. If not, skip.

--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -23,8 +23,8 @@ spec:
               value: "60"
             - name: LABEL_KEY
               value: doks.digitalocean.com/node-pool
-            - name: LABEL_VALUE
-              value: sfu
+            - name: LABEL_VALUES
+              value: "sfu, router"
       imagePullSecrets:
         - name: priv-docker-registry
       nodeSelector:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,7 @@ import (
 const (
 	defaultEnv                 = "development"
 	defaultLabelKey            = "doks.digitalocean.com/node-pool"
-	defaultLabelValue          = "sfu"
+	defaultLabelValues         = "sfu"
 	defaultProvider            = "digitalocean"
 	defaultScanIntervalSeconds = "60"
 	defaultToken               = "abcd123"
@@ -22,7 +22,7 @@ const (
 type Config struct {
 	Env                 string
 	LabelKey            string
-	LabelValue          string
+	LabelValues         string
 	Provider            string
 	ScanIntervalSeconds string
 	Token               string
@@ -37,7 +37,7 @@ func FromEnv() *Config {
 		env                 = getenv("ENV", defaultEnv)
 		scanIntervalSeconds = getenv("INTERVAL", defaultScanIntervalSeconds)
 		labelKey            = getenv("LABEL_KEY", defaultLabelKey)
-		labelValue          = getenv("LABEL_VALUE", defaultLabelValue)
+		labelValues         = getenv("LABEL_VALUES", defaultLabelValues)
 		provider            = getenv("PROVIDER", defaultProvider)
 		token               = getenv("TOKEN", defaultToken)
 		subdomain           = getenv("SUBDOMAIN", defaultSubdomain)
@@ -48,7 +48,7 @@ func FromEnv() *Config {
 		Env:                 env,
 		ScanIntervalSeconds: scanIntervalSeconds,
 		LabelKey:            labelKey,
-		LabelValue:          labelValue,
+		LabelValues:         labelValues,
 		Provider:            provider,
 		Token:               token,
 		Subdomain:           subdomain,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,7 +25,7 @@ func TestFromEnv(t *testing.T) {
 	setenv(t, "INTERVAL", "61")
 	setenv(t, "PROVIDER", "digitalocean")
 	setenv(t, "LABEL_KEY", "doks.digitalocean.com/node-pool")
-	setenv(t, "LABEL_VALUE", "sfu")
+	setenv(t, "LABEL_VALUES", "sfu")
 	setenv(t, "TOKEN", "abcd1231")
 	setenv(t, "SUBDOMAIN", "dev")
 	setenv(t, "ZONE", "k8s.gather.town")
@@ -44,8 +44,8 @@ func TestFromEnv(t *testing.T) {
 		t.Errorf("FromEnv() 'LABEL_KEY' = %q; want %q", got, want)
 	}
 
-	if got, want := cfg.LabelValue, "sfu"; got != want {
-		t.Errorf("FromEnv() 'LABEL_VALUE' = %q; want %q", got, want)
+	if got, want := cfg.LabelValues, "sfu"; got != want {
+		t.Errorf("FromEnv() 'LABEL_VALUES' = %q; want %q", got, want)
 	}
 
 	if got, want := cfg.Provider, "digitalocean"; got != want {
@@ -68,7 +68,7 @@ func TestFromEnv(t *testing.T) {
 	unsetenv(t, "INTERVAL")
 	unsetenv(t, "PROVIDER")
 	unsetenv(t, "LABEL_KEY")
-	unsetenv(t, "LABEL_VALUE")
+	unsetenv(t, "LABEL_VALUES")
 	unsetenv(t, "TOKEN")
 	unsetenv(t, "SUBDOMAIN")
 	unsetenv(t, "ZONE")

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -21,7 +21,7 @@ var logger = log.New(os.Stdout, cfg.Env)
 func (c *Cluster) Nodes() ([]Node, error) {
 	var nodes []Node
 
-	n, err := c.GetNodes(cfg.LabelKey, cfg.LabelValue)
+	n, err := c.GetNodes(cfg.LabelKey, cfg.LabelValues)
 	if err != nil {
 		return nil, err
 	}
@@ -34,8 +34,8 @@ func (c *Cluster) Nodes() ([]Node, error) {
 }
 
 // GetNodes returns the list of cluster nodes
-func (c *Cluster) GetNodes(labelKey string, labelValue string) (*v1.NodeList, error) {
-	labelSelector := fmt.Sprintf("%s=%s", labelKey, labelValue)
+func (c *Cluster) GetNodes(labelKey string, labelValues string) (*v1.NodeList, error) {
+	labelSelector := fmt.Sprintf("%s in (%s)", labelKey, labelValues)
 	opts := metav1.ListOptions{
 		LabelSelector: labelSelector,
 		Limit:         300,


### PR DESCRIPTION
## WHAT
This PR enables the functionality of accepting multiple labelValues

## WHY
To monitor multiple kubernetes nodes with different labels.

## TESTS
Tested locally:
```bash
➜  casper-3 git:(dev/achilleas-ENG-2191) ✗ make test
go test -v -coverpkg=./... -coverprofile=profile.cov ./...
?   	github.com/gathertown/casper-3/cmd/casper-3	[no test files]
=== RUN   TestFromEnv
    config_test.go:24: Setting env "ENV"="development"
    config_test.go:25: Setting env "INTERVAL"="61"
    config_test.go:26: Setting env "PROVIDER"="digitalocean"
    config_test.go:27: Setting env "LABEL_KEY"="doks.digitalocean.com/node-pool"
    config_test.go:28: Setting env "LABEL_VALUES"="sfu"
    config_test.go:29: Setting env "TOKEN"="abcd1231"
    config_test.go:30: Setting env "SUBDOMAIN"="dev"
    config_test.go:31: Setting env "ZONE"="k8s.gather.town"
--- PASS: TestFromEnv (0.00s)
PASS
coverage: 5.7% of statements in ./...
ok  	github.com/gathertown/casper-3/internal/config	0.019s	coverage: 5.7% of statements in ./...
?   	github.com/gathertown/casper-3/pkg	[no test files]
=== RUN   TestGetNodes
    nodes_test.go:77: Setting env "LABEL_VALUES"="sfu,router"
--- PASS: TestGetNodes (0.00s)
PASS
coverage: 7.8% of statements in ./...
ok  	github.com/gathertown/casper-3/pkg/kubernetes	0.041s	coverage: 7.8% of statements in ./...
=== RUN   TestNew
--- PASS: TestNew (0.00s)
=== RUN   TestToMap
=== RUN   TestToMap/empty_input
=== RUN   TestToMap/key_without_value
=== RUN   TestToMap/key_without_value_at_end
=== RUN   TestToMap/typical_case
=== RUN   TestToMap/same_key_should_overwrite_value
--- PASS: TestToMap (0.00s)
    --- PASS: TestToMap/empty_input (0.00s)
    --- PASS: TestToMap/key_without_value (0.00s)
    --- PASS: TestToMap/key_without_value_at_end (0.00s)
    --- PASS: TestToMap/typical_case (0.00s)
    --- PASS: TestToMap/same_key_should_overwrite_value (0.00s)
PASS
coverage: 9.0% of statements in ./...
ok  	github.com/gathertown/casper-3/pkg/log	0.019s	coverage: 9.0% of statements in ./...
?   	github.com/gathertown/casper-3/pkg/providers/cloudflare	[no test files]
?   	github.com/gathertown/casper-3/pkg/providers/digitalocean	[no test files]
go tool cover -func profile.cov
github.com/gathertown/casper-3/cmd/casper-3/main.go:24:				main		0.0%
github.com/gathertown/casper-3/internal/config/config.go:35:			FromEnv		100.0%
github.com/gathertown/casper-3/internal/config/config.go:60:			getenv		100.0%
github.com/gathertown/casper-3/pkg/common.go:11:				Compare		0.0%
github.com/gathertown/casper-3/pkg/kubernetes/kubernetes.go:16:			New		0.0%
github.com/gathertown/casper-3/pkg/kubernetes/nodes.go:21:			Nodes		0.0%
github.com/gathertown/casper-3/pkg/kubernetes/nodes.go:37:			GetNodes	83.3%
github.com/gathertown/casper-3/pkg/log/log.go:33:				New		100.0%
github.com/gathertown/casper-3/pkg/log/log.go:51:				Info		100.0%
github.com/gathertown/casper-3/pkg/log/log.go:57:				Debug		100.0%
github.com/gathertown/casper-3/pkg/log/log.go:61:				toMap		100.0%
github.com/gathertown/casper-3/pkg/providers/cloudflare/dnsrecord.go:22:	NewCFClient	0.0%
github.com/gathertown/casper-3/pkg/providers/cloudflare/dnsrecord.go:30:	Sync		0.0%
github.com/gathertown/casper-3/pkg/providers/cloudflare/dnsrecord.go:106:	getRecords	0.0%
github.com/gathertown/casper-3/pkg/providers/cloudflare/dnsrecord.go:126:	deleteRecord	0.0%
github.com/gathertown/casper-3/pkg/providers/cloudflare/dnsrecord.go:159:	addRecord	0.0%
github.com/gathertown/casper-3/pkg/providers/cloudflare/dnsrecord.go:205:	compare		0.0%
github.com/gathertown/casper-3/pkg/providers/digitalocean/dnsrecord.go:22:	NewDOClient	0.0%
github.com/gathertown/casper-3/pkg/providers/digitalocean/dnsrecord.go:26:	Sync		0.0%
github.com/gathertown/casper-3/pkg/providers/digitalocean/dnsrecord.go:98:	getRecords	0.0%
github.com/gathertown/casper-3/pkg/providers/digitalocean/dnsrecord.go:112:	deleteRecord	0.0%
github.com/gathertown/casper-3/pkg/providers/digitalocean/dnsrecord.go:141:	addRecord	0.0%
total:										(statements)	11.4%
rm profile.cov
```

https://linear.app/gather-town/issue/ENG-2191/update-casper-3-to-accept-multiple-labelvalues