### PR TITLE
[feat]: Monitor pod labels and create DNS records based on pod names

### DIFF
--- a/cmd/casper-3/main.go
+++ b/cmd/casper-3/main.go
@@ -24,14 +24,14 @@ type provider interface {
 func main() {
 	// Generic configuration setup
 	cfg := config.FromEnv()
-	logger := log.New(os.Stdout, cfg.Env)
+	logger := log.New(os.Stdout, cfg.LogLevel)
 	interval, err := strconv.ParseInt(cfg.ScanIntervalSeconds, 10, 64)
 	if err != nil {
 		msg := fmt.Sprintf("%v", err)
 		logger.Info(msg)
 		return
 	}
-	logger.Info("Launching casper-3", "labelKey", cfg.LabelKey, "labelValues", cfg.LabelValues, "interval", cfg.ScanIntervalSeconds, "environment", cfg.Env, "TXT identifier", fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env))
+	logger.Info("Launching casper-3", "labelKey", cfg.LabelKey, "labelValues", cfg.LabelValues, "interval", cfg.ScanIntervalSeconds, "environment", cfg.Env, "TXT identifier", fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env), "logLevel", cfg.LogLevel)
 
 	// Run loop based on interval. Check if there are unlabelled instances.
 	// If there are unlabelled instances, add label. If not, skip.

--- a/cmd/casper-3/main.go
+++ b/cmd/casper-3/main.go
@@ -17,7 +17,7 @@ import (
 
 type Node = common.Node
 type provider interface {
-	Sync(nodes []Node) (bool, error)
+	Sync(nodes []Node)
 }
 
 // run labels nodes if label is missing
@@ -55,11 +55,7 @@ func main() {
 			fmt.Println(err)
 		}
 
-		_, err = p.Sync(n)
-		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			logger.Info(msg)
-		}
+		p.Sync(n)
 
 		time.Sleep(time.Duration(interval) * time.Second)
 	}

--- a/deployments/base/clusterrole.yaml
+++ b/deployments/base/clusterrole.yaml
@@ -9,5 +9,7 @@ rules:
       - "*"
     resources:
       - nodes
+      - pods
     verbs:
       - list
+      - get

--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -25,6 +25,8 @@ spec:
               value: doks.digitalocean.com/node-pool
             - name: LABEL_VALUES
               value: "sfu, router"
+            - name: ALLOW_SYNC_PODS
+              value: "true"
       imagePullSecrets:
         - name: priv-docker-registry
       nodeSelector:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,9 @@ const (
 	defaultZone                = "k8s.gather.town"
 	defaultSubdomain           = ""     // effective only for DigitalOcean provider
 	defaultLogLevel            = "info" // use to "debug" for debug level, everything else is INFO
+	defaultAllowSyncPods       = "false"
+	defaultSyncPodLabelKey     = "casper-3.gather.town/sync"
+	defaultSyncPodLabelValue   = "true"
 )
 
 // Config contains service information that can be changed from the
@@ -30,6 +33,9 @@ type Config struct {
 	Zone                string
 	Subdomain           string
 	LogLevel            string
+	AllowSyncPods       string
+	SyncPodLabelKey     string
+	SyncPodLabelValue   string
 }
 
 // FromEnv returns the service configuration from the environment variables.
@@ -45,6 +51,9 @@ func FromEnv() *Config {
 		subdomain           = getenv("SUBDOMAIN", defaultSubdomain)
 		zone                = getenv("ZONE", defaultZone)
 		logLevel            = getenv("LOGLEVEL", defaultLogLevel)
+		allowSyncPods       = getenv("ALLOW_SYNC_PODS", defaultAllowSyncPods)
+		syncPodLabelKey     = getenv("SYNC_POD_LABEL_KEY", defaultSyncPodLabelKey)
+		syncPodLabelValue   = getenv("SYNC_POD_LABEL_VALUE", defaultSyncPodLabelValue)
 	)
 
 	c := &Config{
@@ -57,6 +66,9 @@ func FromEnv() *Config {
 		Subdomain:           subdomain,
 		Zone:                zone,
 		LogLevel:            logLevel,
+		AllowSyncPods:       allowSyncPods,
+		SyncPodLabelKey:     syncPodLabelKey,
+		SyncPodLabelValue:   syncPodLabelValue,
 	}
 	return c
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,8 @@ const (
 	defaultScanIntervalSeconds = "60"
 	defaultToken               = "abcd123"
 	defaultZone                = "k8s.gather.town"
-	defaultSubdomain           = "" // effective only for DigitalOcean provider
+	defaultSubdomain           = ""     // effective only for DigitalOcean provider
+	defaultLogLevel            = "info" // use to "debug" for debug level, everything else is INFO
 )
 
 // Config contains service information that can be changed from the
@@ -28,6 +29,7 @@ type Config struct {
 	Token               string
 	Zone                string
 	Subdomain           string
+	LogLevel            string
 }
 
 // FromEnv returns the service configuration from the environment variables.
@@ -42,6 +44,7 @@ func FromEnv() *Config {
 		token               = getenv("TOKEN", defaultToken)
 		subdomain           = getenv("SUBDOMAIN", defaultSubdomain)
 		zone                = getenv("ZONE", defaultZone)
+		logLevel            = getenv("LOGLEVEL", defaultLogLevel)
 	)
 
 	c := &Config{
@@ -53,6 +56,7 @@ func FromEnv() *Config {
 		Token:               token,
 		Subdomain:           subdomain,
 		Zone:                zone,
+		LogLevel:            logLevel,
 	}
 	return c
 }

--- a/pkg/common.go
+++ b/pkg/common.go
@@ -6,6 +6,12 @@ type Node struct {
 	ExternalIP string
 }
 
+type Pod struct {
+	Name         string
+	AssignedNode Node
+	Labels       map[string]string
+}
+
 // Compare slices: https://stackoverflow.com/a/45428032/577133
 // Returns []string of elements found in 'a' but not in 'b'.
 func Compare(a, b []string) []string {

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -15,7 +15,7 @@ import (
 type Node = common.Node
 
 var cfg = config.FromEnv()
-var logger = log.New(os.Stdout, cfg.Env)
+var logger = log.New(os.Stdout, cfg.LogLevel)
 
 // Returns []Node struct listing hostname and IPv4 address
 func (c *Cluster) Nodes() ([]Node, error) {

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -17,7 +17,7 @@ type Node = common.Node
 var cfg = config.FromEnv()
 var logger = log.New(os.Stdout, cfg.Env)
 
-// GetNodes returns the list of cluster nodes
+// Returns []Node struct listing hostname and IPv4 address
 func (c *Cluster) Nodes() ([]Node, error) {
 	var nodes []Node
 
@@ -27,7 +27,12 @@ func (c *Cluster) Nodes() ([]Node, error) {
 	}
 
 	for _, node := range n.Items {
-		nodes = append(nodes, Node{node.Name, node.Status.Addresses[2].Address})
+		if len(node.Status.Addresses) < 3 {
+			logger.Info("No IPv4 address found", "node", node.Name)
+		} else {
+			logger.Debug("IPv4 address found", "node", node.Name)
+			nodes = append(nodes, Node{node.Name, node.Status.Addresses[2].Address})
+		}
 	}
 
 	return nodes, nil

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -51,3 +51,12 @@ func (c *Cluster) GetNodes(labelKey string, labelValues string) (*v1.NodeList, e
 	}
 	return n, nil
 }
+
+func (c *Cluster) getExternalIpByNodeName(nodeName string) (string, error) {
+	n, err := c.Client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	ip := n.Status.Addresses[2].Address
+	return ip, nil
+}

--- a/pkg/kubernetes/nodes_test.go
+++ b/pkg/kubernetes/nodes_test.go
@@ -129,3 +129,25 @@ func TestNoIPv4(t *testing.T) {
 	}
 	unsetenv(t, "LABEL_VALUES")
 }
+
+func TestGetExternalIpByNode(t *testing.T) {
+	c := setupCluster(t)
+	cfg := config.FromEnv()
+	nodes := 2
+	n, _ := c.GetNodes(cfg.LabelKey, cfg.LabelValues)
+
+	// test number of nodes with label
+	if len(n.Items) != nodes {
+		t.Errorf("Expecting %v nodes, got %v nodes", nodes, len(n.Items))
+	}
+
+	expectedExternalIPAddressList := []string{"1.1.1.1", "1.1.1.2"}
+
+	// fetch pod names
+	for _, node := range n.Items {
+		actualExternalIPAddress, _ := c.getExternalIpByNodeName(node.Name)
+		if !contains(expectedExternalIPAddressList, actualExternalIPAddress) {
+			t.Errorf("Expecting one of the following IP Addresses(s) %v, got %v IP Address", expectedExternalIPAddressList, actualExternalIPAddress)
+		}
+	}
+}

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	common "github.com/gathertown/casper-3/pkg"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Pod = common.Pod
+
+// Returns []Pod struct listing pod name, assigned Node and podLabels
+func (c *Cluster) Pods() ([]Pod, error) {
+	var pods []Pod
+
+	p, err := c.GetPods(cfg.SyncPodLabelKey, cfg.SyncPodLabelValue)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range p.Items {
+		externalIp, err := c.getExternalIpByNodeName(pod.Spec.NodeName)
+		if err != nil {
+			return nil, err
+		}
+		podLabels := make(map[string]string)
+		podLabels = pod.Labels
+		pods = append(pods, Pod{pod.Name, Node{pod.Spec.NodeName, externalIp}, podLabels})
+	}
+
+	return pods, nil
+}
+
+// GetPods returns the list of cluster pods with the label: casper-3.gather.town/sync=true
+func (c *Cluster) GetPods(labelKey string, labelValue string) (*v1.PodList, error) {
+	labelSelector := fmt.Sprintf("%s=%s", labelKey, labelValue)
+	opts := metav1.ListOptions{
+		LabelSelector: labelSelector,
+		Limit:         300,
+	}
+	p, err := c.Client.CoreV1().Pods("").List(context.TODO(), opts)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/pkg/kubernetes/pods_test.go
+++ b/pkg/kubernetes/pods_test.go
@@ -1,0 +1,85 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gathertown/casper-3/internal/config"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	f "k8s.io/client-go/kubernetes/fake"
+)
+
+var mockPodsOpts = []struct {
+	podName    string
+	labelKey   string
+	labelValue string
+}{
+	{"router-0", cfg.SyncPodLabelKey, cfg.SyncPodLabelValue},
+	{"router-1", "casper-3.gather.town/sync", "true"},
+	{"router-2", "casper-3.gather.town", "false"},
+	{"router-3", "casper-3.gather.town/domain", ""},
+	{"router-4", "casper-3.gather.town/donothing", "nil"},
+}
+
+var mockNodeOpts = struct {
+	localIP     string
+	internalIP  string
+	externalIP  string
+	clusterName string
+	nodeName    string
+	labelKey    string
+	labelValue  string
+}{
+	"127.0.0.1", "10.0.0.1", "1.1.1.1", "test", "sfu-8mh0d", config.FromEnv().LabelKey, "sfu",
+}
+
+func setupClusterWithPods(t *testing.T) Cluster {
+	t.Helper()
+	c := Cluster{Client: f.NewSimpleClientset()}
+	opts := metav1.CreateOptions{}
+	labels := map[string]string{
+		mockNodeOpts.labelKey: mockNodeOpts.labelValue,
+	}
+	nodeStatus := v1.NodeStatus{
+		Addresses: []v1.NodeAddress{
+			{Type: v1.NodeHostName, Address: mockNodeOpts.localIP},
+			{Type: v1.NodeInternalIP, Address: mockNodeOpts.internalIP},
+			{Type: v1.NodeExternalIP, Address: mockNodeOpts.externalIP},
+		},
+	}
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: mockNodeOpts.nodeName, ClusterName: mockNodeOpts.clusterName, Labels: labels}, Status: nodeStatus}
+	_, _ = c.Client.CoreV1().Nodes().Create(context.TODO(), node, opts)
+
+	for _, p := range mockPodsOpts {
+		podLabels := map[string]string{
+			p.labelKey: p.labelValue,
+		}
+		pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: p.podName, Labels: podLabels}, Spec: v1.PodSpec{NodeName: node.Name}}
+		_, _ = c.Client.CoreV1().Pods("").Create(context.TODO(), pod, opts)
+
+	}
+	return c
+}
+
+func TestGetPods(t *testing.T) {
+	c := setupClusterWithPods(t)
+	cfg := config.FromEnv()
+	pods := 2
+	p, _ := c.GetPods(cfg.SyncPodLabelKey, cfg.SyncPodLabelValue)
+
+	// test number of pods with label
+	if len(p.Items) != pods {
+		t.Errorf("Expecting %v pods, got %v pods", pods, len(p.Items))
+	}
+
+	podNamesList := []string{"router-0", "router-1"}
+
+	// fetch pod names
+	for _, pod := range p.Items {
+		if !contains(podNamesList, pod.Name) {
+			t.Errorf("Expecting one of the following pod Name(s) %v, got %v pods", podNamesList, pod.Name)
+		}
+	}
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -30,13 +30,13 @@ type Logger struct {
 
 // New creates a new structured logger. When develop is true, it provides the
 // output in logfmt format. Otherwise the output is JSON.
-func New(out io.Writer, env string) *Logger {
+func New(out io.Writer, level string) *Logger {
 	var log = logrus.New()
 	log.SetOutput(out)
 
 	// 	log.Formatter = &logrus.JSONFormatter{}
 	log.Formatter = &logrus.TextFormatter{}
-	if env == "development" {
+	if level == "debug" {
 		log.SetLevel(logrus.DebugLevel)
 	}
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNew(t *testing.T) {
 	var buf bytes.Buffer
-	logger := New(&buf, "development")
+	logger := New(&buf, "debug")
 
 	logger.Debug("foo")
 	if got, want := buf.String(), "level=debug msg=foo"; !strings.Contains(got, want) {

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -13,7 +13,7 @@ import (
 )
 
 var cfg = config.FromEnv()
-var logger = log.New(os.Stdout, cfg.Env)
+var logger = log.New(os.Stdout, cfg.LogLevel)
 var label = fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env)
 
 type Node = common.Node
@@ -92,6 +92,9 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 		for _, name := range deleteEntries {
 			// The 'Name' entry is the FQDN
 			cName := fmt.Sprintf("%s.%s", name, cfg.Zone)
+			if cfg.Subdomain != "" {
+				cName = fmt.Sprintf("%s.%s.%s", name, cfg.Subdomain, cfg.Zone)
+			}
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -27,7 +27,7 @@ func NewCFClient() *cloudflare.API {
 	return api
 }
 
-func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
+func (d CloudFlareDNS) Sync(nodes []Node) {
 	var nodeHostnames, dnsRecords []string
 
 	// Setup the client
@@ -41,7 +41,8 @@ func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
 	if err != nil {
 		msg := fmt.Sprintf("%v", err)
 		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "error", msg)
-		return false, err
+		logger.Info(err.Error())
+		return
 	}
 
 	// Generate arrays
@@ -78,7 +79,7 @@ func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
 			} else {
 				_, err := addRecord(context.TODO(), client, cfg.Zone, cfg.Subdomain, name, addressIPv4, cfg.Env)
 				if err != nil {
-					return false, err
+					logger.Info(err.Error())
 				}
 			}
 		}
@@ -94,13 +95,13 @@ func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				return false, err
+				logger.Info(err.Error())
 			}
 		}
 	}
 
 	// Find kubernetes nodes to register
-	return true, nil
+	return
 }
 
 func getRecords(ctx context.Context, client *cloudflare.API, zone string, recordType string) ([]cloudflare.DNSRecord, error) {

--- a/pkg/providers/digitalocean/dnsrecord.go
+++ b/pkg/providers/digitalocean/dnsrecord.go
@@ -13,7 +13,7 @@ import (
 )
 
 var cfg = config.FromEnv()
-var logger = log.New(os.Stdout, cfg.Env)
+var logger = log.New(os.Stdout, cfg.LogLevel)
 var label = fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env)
 
 type Node = common.Node

--- a/pkg/providers/digitalocean/dnsrecord.go
+++ b/pkg/providers/digitalocean/dnsrecord.go
@@ -23,7 +23,7 @@ func NewDOClient() *godo.Client {
 	return godo.NewFromToken(cfg.Token)
 }
 
-func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
+func (d DigitalOceanDNS) Sync(nodes []Node) {
 	var nodeHostnames, dnsRecords []string
 
 	// Setup the client
@@ -36,7 +36,8 @@ func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
 	txtRecords, err := getRecords(context.TODO(), client, cfg.Zone, recordType)
 	if err != nil {
 		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain)
-		return false, err
+		logger.Info(err.Error())
+		return
 	}
 
 	// Generate arrays
@@ -71,7 +72,7 @@ func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
 			} else {
 				_, err := addRecord(context.TODO(), client, cfg.Zone, name, cfg.Subdomain, addressIPv4, cfg.Env)
 				if err != nil {
-					return false, err
+					logger.Info(err.Error())
 				}
 			}
 		}
@@ -86,13 +87,13 @@ func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				return false, err
+				logger.Info(err.Error())
 			}
 		}
 	}
 
 	// Find kubernetes nodes to register
-	return true, nil
+	return
 }
 
 func getRecords(ctx context.Context, client *godo.Client, domain string, recordType string) ([]godo.DomainRecord, error) {


### PR DESCRIPTION
## Description
This PR adds the functionality to casper-3 to monitor certain pod labels and create dns records based on their name.

## Why
This feature can be used from statefulsets that use the hostNetwork mode.
In that case, pods will be created with a name that follows this pattern: 
```
{sts-name}-{ordinal-index}
```
Since casper-3 already creates DNS records for k8s nodes, if we use hostNetwork mode, we could just use those DNS records. But that's not always convenient and can be dangerous.

There are cases, like routers, that all available endpoints need to be known from other applications.
If we consider the k8s node DNS record as the router record, that can lead to outage in case the k8s node change.
By adding the `casper-3.gather.town/sync: "true"` label on the statefulset, casper-3 will create and maintain DNS records with the following specs:
TXT record:
1. cName: the pod name. i.e. `router-1.gather.town`
2. TXTdata: `"heritage=casper-3,pod-sync=true,environment=$ENV,podName=$POD_NAME,assignedNode=$NODE_NAME,addressIPv4=$IP"`

A record:
1. cName: the pod name. i.e. `router-1.gather.town`
2. addressIPv4: the addressIPv4 of the assigned k8s node, where the pod is running

In this way, apps will always reach the `router-1.gather.town` endpoint, regardless of the node that belongs to.

## Test
1. Created some test cases for the Pods() function 
2. Need to test it also in an actual environment to verify that works as expected - WIP 