### PR TITLE
feat: Handle lack of IPv4 address gracefully

### DIFF
--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -17,7 +17,7 @@ type Node = common.Node
 var cfg = config.FromEnv()
 var logger = log.New(os.Stdout, cfg.Env)
 
-// GetNodes returns the list of cluster nodes
+// Returns []Node struct listing hostname and IPv4 address
 func (c *Cluster) Nodes() ([]Node, error) {
 	var nodes []Node
 
@@ -27,7 +27,12 @@ func (c *Cluster) Nodes() ([]Node, error) {
 	}
 
 	for _, node := range n.Items {
-		nodes = append(nodes, Node{node.Name, node.Status.Addresses[2].Address})
+		if len(node.Status.Addresses) < 3 {
+			logger.Info("No IPv4 address found", "node", node.Name)
+		} else {
+			logger.Debug("IPv4 address found", "node", node.Name)
+			nodes = append(nodes, Node{node.Name, node.Status.Addresses[2].Address})
+		}
 	}
 
 	return nodes, nil


### PR DESCRIPTION
If IPv4 address is not found on a node, the application panics:

```
goroutine 1 [running]:
github.com/gathertown/casper-3/pkg/kubernetes.(*Cluster).Nodes(0xc0003f3d20, 0x0, 0x0, 0xc00021bed8, 0xa, 0xa)
	/app/pkg/kubernetes/nodes.go:30 +0x2ae
main.main()
	/app/cmd/casper-3/main.go:53 +0x4d5

```

This PR handles this situation gracefully. If the IPv4 address is not
found, we're not adding the node the list of existing nods in the
kubernetes cluster.