### PR TITLE
[fix]: log errors instead of return them on Sync() function, to allow routine completion

### DIFF
--- a/cmd/casper-3/main.go
+++ b/cmd/casper-3/main.go
@@ -17,7 +17,7 @@ import (
 
 type Node = common.Node
 type provider interface {
-	Sync(nodes []Node) (bool, error)
+	Sync(nodes []Node)
 }
 
 // run labels nodes if label is missing
@@ -55,11 +55,7 @@ func main() {
 			fmt.Println(err)
 		}
 
-		_, err = p.Sync(n)
-		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			logger.Info(msg)
-		}
+		p.Sync(n)
 
 		time.Sleep(time.Duration(interval) * time.Second)
 	}

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -27,7 +27,7 @@ func NewCFClient() *cloudflare.API {
 	return api
 }
 
-func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
+func (d CloudFlareDNS) Sync(nodes []Node) {
 	var nodeHostnames, dnsRecords []string
 
 	// Setup the client
@@ -41,7 +41,8 @@ func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
 	if err != nil {
 		msg := fmt.Sprintf("%v", err)
 		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "error", msg)
-		return false, err
+		logger.Info(err.Error())
+		return
 	}
 
 	// Generate arrays
@@ -78,7 +79,7 @@ func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
 			} else {
 				_, err := addRecord(context.TODO(), client, cfg.Zone, cfg.Subdomain, name, addressIPv4, cfg.Env)
 				if err != nil {
-					return false, err
+					logger.Info(err.Error())
 				}
 			}
 		}
@@ -94,13 +95,13 @@ func (d CloudFlareDNS) Sync(nodes []Node) (bool, error) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				return false, err
+				logger.Info(err.Error())
 			}
 		}
 	}
 
 	// Find kubernetes nodes to register
-	return true, nil
+	return
 }
 
 func getRecords(ctx context.Context, client *cloudflare.API, zone string, recordType string) ([]cloudflare.DNSRecord, error) {

--- a/pkg/providers/digitalocean/dnsrecord.go
+++ b/pkg/providers/digitalocean/dnsrecord.go
@@ -23,7 +23,7 @@ func NewDOClient() *godo.Client {
 	return godo.NewFromToken(cfg.Token)
 }
 
-func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
+func (d DigitalOceanDNS) Sync(nodes []Node) {
 	var nodeHostnames, dnsRecords []string
 
 	// Setup the client
@@ -36,7 +36,8 @@ func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
 	txtRecords, err := getRecords(context.TODO(), client, cfg.Zone, recordType)
 	if err != nil {
 		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain)
-		return false, err
+		logger.Info(err.Error())
+		return
 	}
 
 	// Generate arrays
@@ -71,7 +72,7 @@ func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
 			} else {
 				_, err := addRecord(context.TODO(), client, cfg.Zone, name, cfg.Subdomain, addressIPv4, cfg.Env)
 				if err != nil {
-					return false, err
+					logger.Info(err.Error())
 				}
 			}
 		}
@@ -86,13 +87,13 @@ func (d DigitalOceanDNS) Sync(nodes []Node) (bool, error) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				return false, err
+				logger.Info(err.Error())
 			}
 		}
 	}
 
 	// Find kubernetes nodes to register
-	return true, nil
+	return
 }
 
 func getRecords(ctx context.Context, client *godo.Client, domain string, recordType string) ([]godo.DomainRecord, error) {


### PR DESCRIPTION
## Description
Log errors instead of return them, to allow routine to proceed with cleanup in case a record creation failed.