### PR TITLE
refactor: decouple log level from environment

### DIFF
--- a/cmd/casper-3/main.go
+++ b/cmd/casper-3/main.go
@@ -24,14 +24,14 @@ type provider interface {
 func main() {
 	// Generic configuration setup
 	cfg := config.FromEnv()
-	logger := log.New(os.Stdout, cfg.Env)
+	logger := log.New(os.Stdout, cfg.LogLevel)
 	interval, err := strconv.ParseInt(cfg.ScanIntervalSeconds, 10, 64)
 	if err != nil {
 		msg := fmt.Sprintf("%v", err)
 		logger.Info(msg)
 		return
 	}
-	logger.Info("Launching casper-3", "labelKey", cfg.LabelKey, "labelValues", cfg.LabelValues, "interval", cfg.ScanIntervalSeconds, "environment", cfg.Env, "TXT identifier", fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env))
+	logger.Info("Launching casper-3", "labelKey", cfg.LabelKey, "labelValues", cfg.LabelValues, "interval", cfg.ScanIntervalSeconds, "environment", cfg.Env, "TXT identifier", fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env), "logLevel", cfg.LogLevel)
 
 	// Run loop based on interval. Check if there are unlabelled instances.
 	// If there are unlabelled instances, add label. If not, skip.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,8 @@ const (
 	defaultScanIntervalSeconds = "60"
 	defaultToken               = "abcd123"
 	defaultZone                = "k8s.gather.town"
-	defaultSubdomain           = "" // effective only for DigitalOcean provider
+	defaultSubdomain           = ""     // effective only for DigitalOcean provider
+	defaultLogLevel            = "info" // use to "debug" for debug level, everything else is INFO
 )
 
 // Config contains service information that can be changed from the
@@ -28,6 +29,7 @@ type Config struct {
 	Token               string
 	Zone                string
 	Subdomain           string
+	LogLevel            string
 }
 
 // FromEnv returns the service configuration from the environment variables.
@@ -42,6 +44,7 @@ func FromEnv() *Config {
 		token               = getenv("TOKEN", defaultToken)
 		subdomain           = getenv("SUBDOMAIN", defaultSubdomain)
 		zone                = getenv("ZONE", defaultZone)
+		logLevel            = getenv("LOGLEVEL", defaultLogLevel)
 	)
 
 	c := &Config{
@@ -53,6 +56,7 @@ func FromEnv() *Config {
 		Token:               token,
 		Subdomain:           subdomain,
 		Zone:                zone,
+		LogLevel:            logLevel,
 	}
 	return c
 }

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -15,7 +15,7 @@ import (
 type Node = common.Node
 
 var cfg = config.FromEnv()
-var logger = log.New(os.Stdout, cfg.Env)
+var logger = log.New(os.Stdout, cfg.LogLevel)
 
 // Returns []Node struct listing hostname and IPv4 address
 func (c *Cluster) Nodes() ([]Node, error) {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -30,13 +30,13 @@ type Logger struct {
 
 // New creates a new structured logger. When develop is true, it provides the
 // output in logfmt format. Otherwise the output is JSON.
-func New(out io.Writer, env string) *Logger {
+func New(out io.Writer, level string) *Logger {
 	var log = logrus.New()
 	log.SetOutput(out)
 
 	// 	log.Formatter = &logrus.JSONFormatter{}
 	log.Formatter = &logrus.TextFormatter{}
-	if env == "development" {
+	if level == "debug" {
 		log.SetLevel(logrus.DebugLevel)
 	}
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNew(t *testing.T) {
 	var buf bytes.Buffer
-	logger := New(&buf, "development")
+	logger := New(&buf, "debug")
 
 	logger.Debug("foo")
 	if got, want := buf.String(), "level=debug msg=foo"; !strings.Contains(got, want) {

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -92,6 +92,9 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 		for _, name := range deleteEntries {
 			// The 'Name' entry is the FQDN
 			cName := fmt.Sprintf("%s.%s", name, cfg.Zone)
+			if cfg.Subdomain != "" {
+				cName = fmt.Sprintf("%s.%s.%s", name, cfg.Subdomain, cfg.Zone)
+			}
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -13,7 +13,7 @@ import (
 )
 
 var cfg = config.FromEnv()
-var logger = log.New(os.Stdout, cfg.Env)
+var logger = log.New(os.Stdout, cfg.LogLevel)
 var label = fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env)
 
 type Node = common.Node

--- a/pkg/providers/digitalocean/dnsrecord.go
+++ b/pkg/providers/digitalocean/dnsrecord.go
@@ -13,7 +13,7 @@ import (
 )
 
 var cfg = config.FromEnv()
-var logger = log.New(os.Stdout, cfg.Env)
+var logger = log.New(os.Stdout, cfg.LogLevel)
 var label = fmt.Sprintf("heritage=casper-3,environment=%s", cfg.Env)
 
 type Node = common.Node


### PR DESCRIPTION
We're using the environment flag in to generate the TXT records. Using
"development" environment in a production cluster will break
consistency, as the records will have a different flag.

Introducing the `LOGLEVEL` var to enable debug mode.