### PR TITLE
[fix]: get the textRecord Content instead of Data

### DIFF
--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -159,7 +159,7 @@ func (c CloudFlareDNS) SyncPods(pods []Pod) {
 
 	// Generate arrays
 	for _, txtRecord := range txtRecords {
-		recordData := fmt.Sprintf("%v", txtRecord.Data) // convert interface{} to string
+		recordData := fmt.Sprintf("%v", txtRecord.Content) // convert interface{} to string
 
 		if strings.Contains(recordData, "pod-sync=true") { // save only the txtRecords that have been created from a pod-sync operation
 			cName := strings.Split(txtRecord.Name, ".")
@@ -232,7 +232,7 @@ func (c CloudFlareDNS) SyncPods(pods []Pod) {
 		txtLabel := fmt.Sprintf("heritage=casper-3,pod-sync=true,environment=%s,podName=%s,assignedNode=%s,addressIPv4=%s", cfg.Env, podName, assignedNode, addressIPv4)
 		for _, txt := range txtRecordsFromPods {
 			cName := strings.Split(txt.Name, ".")
-			txtData := fmt.Sprintf("%v", txt.Data) // convert interface{} to string
+			txtData := fmt.Sprintf("%v", txt.Content) // convert interface{} to string
 			if cName[0] == podName && !strings.Contains(txtData, assignedNode) {
 				// then delete existing record and recreate new ones
 				logger.Debug("Found a pod with that might got rescheduled on a different node", podName)


### PR DESCRIPTION
## Description

We were trying to fetch txtRecords and compare their labels from the txtRecord.Data field, but txtLabels can be found from the Content field, instead of the Data.
This PR fixes that bug.