### PR TITLE
Panaigiotis/introduce error level log

### DIFF
--- a/cmd/casper-3/main.go
+++ b/cmd/casper-3/main.go
@@ -32,8 +32,7 @@ func main() {
 	logger := log.New(os.Stdout, cfg.LogLevel)
 	interval, err := strconv.ParseInt(cfg.ScanIntervalSeconds, 10, 64)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		logger.Info(msg)
+		logger.Error(err.Error())
 		return
 	}
 
@@ -53,14 +52,12 @@ func main() {
 	for {
 		c, err := kubernetes.New()
 		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			logger.Info(msg)
-			return
+			logger.Error("Error occured while initializing pods", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 		}
 
 		n, err := c.Nodes()
 		if err != nil {
-			fmt.Println(err)
+			logger.Error("Error occured while fetching kubernetes nodes info", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 		}
 
 		p.Sync(n)
@@ -68,8 +65,7 @@ func main() {
 		if syncPodsAllowed, _ := strconv.ParseBool(cfg.AllowSyncPods); syncPodsAllowed {
 			pods, err := c.Pods()
 			if err != nil {
-				msg := fmt.Sprintf("%v", err)
-				logger.Info(msg)
+				logger.Error("Error occured while syncing pods", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 			}
 
 			p.SyncPods(pods)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -3,8 +3,6 @@
 package kubernetes
 
 import (
-	"fmt"
-
 	"github.com/gathertown/casper-3/internal/metrics"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -19,15 +17,13 @@ type Cluster struct {
 func New() (*Cluster, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return nil, err
 	}
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return nil, err
 	}
 	return &Cluster{Client: clientset}, nil

--- a/pkg/kubernetes/nodes.go
+++ b/pkg/kubernetes/nodes.go
@@ -24,8 +24,7 @@ func (c *Cluster) Nodes() ([]Node, error) {
 
 	n, err := c.GetNodes(cfg.LabelKey, cfg.LabelValues)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return nil, err
 	}
 
@@ -50,8 +49,7 @@ func (c *Cluster) GetNodes(labelKey string, labelValues string) (*v1.NodeList, e
 	}
 	n, err := c.Client.CoreV1().Nodes().List(context.TODO(), opts)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return nil, err
 	}
 	return n, nil
@@ -60,8 +58,7 @@ func (c *Cluster) GetNodes(labelKey string, labelValues string) (*v1.NodeList, e
 func (c *Cluster) getExternalIpByNodeName(nodeName string) (string, error) {
 	n, err := c.Client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return "", err
 	}
 	ip := n.Status.Addresses[2].Address

--- a/pkg/kubernetes/pods.go
+++ b/pkg/kubernetes/pods.go
@@ -24,8 +24,7 @@ func (c *Cluster) Pods() ([]Pod, error) {
 	for _, pod := range p.Items {
 		externalIp, err := c.getExternalIpByNodeName(pod.Spec.NodeName)
 		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			metrics.ExecErrInc(msg)
+			metrics.ExecErrInc(err.Error())
 			return nil, err
 		}
 		podLabels := make(map[string]string)
@@ -45,8 +44,7 @@ func (c *Cluster) GetPods(labelKey string, labelValue string) (*v1.PodList, erro
 	}
 	p, err := c.Client.CoreV1().Pods("").List(context.TODO(), opts)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return nil, err
 	}
 	return p, nil

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -61,7 +61,7 @@ func (l *Logger) Debug(message string, keyvals ...interface{}) {
 // Error logs at error log level. For each key, a value should also be provided. If
 // a value is not provided, the key will be ignored.
 func (l *Logger) Error(message string, keyvals ...interface{}) {
-	l.logger.WithFields(toMap(keyvals...)).Debug(message)
+	l.logger.WithFields(toMap(keyvals...)).Error(message)
 }
 
 func toMap(keyvals ...interface{}) map[string]interface{} {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -58,6 +58,12 @@ func (l *Logger) Debug(message string, keyvals ...interface{}) {
 	l.logger.WithFields(toMap(keyvals...)).Debug(message)
 }
 
+// Error logs at error log level. For each key, a value should also be provided. If
+// a value is not provided, the key will be ignored.
+func (l *Logger) Error(message string, keyvals ...interface{}) {
+	l.logger.WithFields(toMap(keyvals...)).Debug(message)
+}
+
 func toMap(keyvals ...interface{}) map[string]interface{} {
 	if len(keyvals)%2 != 0 {
 		keyvals = keyvals[:len(keyvals)-1]

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -46,7 +46,6 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 		if err != nil {
 			metrics.ExecErrInc(err.Error())
 			logger.Error("Error occured while fetching all records", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
-			return
 		}
 		metrics.DNSRecordsTotal(cfg.Provider, allRecords)
 	}()

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -24,9 +24,8 @@ type CloudFlareDNS struct{}
 func NewCFClient() *cloudflare.API {
 	api, err := cloudflare.NewWithAPIToken(cfg.Token)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
-		logger.Info("Error while creating client", "provider", cfg.Provider, "zone", cfg.Zone, "error", msg)
+		metrics.ExecErrInc(err.Error())
+		logger.Error("Error while creating client", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 	}
 	return api
 }
@@ -45,10 +44,8 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 	go func() {
 		allRecords, err := getAllRecords(context.TODO(), client, cfg.Zone)
 		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			metrics.ExecErrInc(msg)
-			logger.Info("Error occured while fetching all records", "provider", cfg.Provider, "zone", cfg.Zone, "error", msg)
-			logger.Info(err.Error())
+			metrics.ExecErrInc(err.Error())
+			logger.Error("Error occured while fetching all records", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 			return
 		}
 		metrics.DNSRecordsTotal(cfg.Provider, allRecords)
@@ -57,10 +54,8 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 	// Fetch all TXT DNS
 	txtRecords, err := getRecords(context.TODO(), client, cfg.Zone, recordType)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
-		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "error", msg)
-		logger.Info(err.Error())
+		metrics.ExecErrInc(err.Error())
+		logger.Error("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 		return
 	}
 
@@ -98,9 +93,8 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 			} else {
 				_, err := addRecord(context.TODO(), client, cfg.Zone, cfg.Subdomain, name, addressIPv4, "", "", cfg.Env)
 				if err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 				}
 			}
 		}
@@ -119,9 +113,8 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				msg := fmt.Sprintf("%v", err)
-				metrics.ExecErrInc(msg)
-				logger.Info(err.Error())
+				metrics.ExecErrInc(err.Error())
+				logger.Error("Error occured while launching deletion", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 			}
 		}
 	}
@@ -150,10 +143,8 @@ func (c CloudFlareDNS) SyncPods(pods []Pod) {
 	// Fetch all TXT DNS
 	txtRecords, err := getRecords(context.TODO(), client, cfg.Zone, recordType)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain)
-		logger.Info(err.Error())
 		return
 	}
 
@@ -197,9 +188,8 @@ func (c CloudFlareDNS) SyncPods(pods []Pod) {
 				txtRecordName := podName
 				_, err := addRecord(context.TODO(), client, cfg.Zone, cfg.Subdomain, podName, addressIPv4, txtRecordName, txtLabel, cfg.Env)
 				if err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while adding records", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 				}
 			}
 		}
@@ -218,9 +208,8 @@ func (c CloudFlareDNS) SyncPods(pods []Pod) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				msg := fmt.Sprintf("%v", err)
-				metrics.ExecErrInc(msg)
-				logger.Info(err.Error())
+				metrics.ExecErrInc(err.Error())
+				logger.Error("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 			}
 		}
 	}
@@ -244,15 +233,13 @@ func (c CloudFlareDNS) SyncPods(pods []Pod) {
 				logger.Debug("Launching deletion", "record", cName)
 				_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 				if err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while deleting record", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 				}
 				_, _err := addRecord(context.TODO(), client, cfg.Zone, cfg.Subdomain, podName, addressIPv4, podName, txtLabel, cfg.Env)
 				if _err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while adding record", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
 				}
 			}
 		}
@@ -266,8 +253,7 @@ func getRecords(ctx context.Context, client *cloudflare.API, zone string, record
 	// Get ZoneID
 	zoneID, err := client.ZoneIDByName(zone)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return nil, err
 	}
 
@@ -276,8 +262,7 @@ func getRecords(ctx context.Context, client *cloudflare.API, zone string, record
 	record := cloudflare.DNSRecord{Type: recordType}
 	records, err := client.DNSRecords(ctx, zoneID, record)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return nil, err
 	}
 
@@ -289,8 +274,7 @@ func deleteRecord(ctx context.Context, client *cloudflare.API, zone string, fqdn
 	// Get ZoneID
 	zoneID, err := client.ZoneIDByName(zone)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 
@@ -299,16 +283,14 @@ func deleteRecord(ctx context.Context, client *cloudflare.API, zone string, fqdn
 	txtRecord := cloudflare.DNSRecord{Name: fqdn, Type: "TXT"}
 	txtRecords, err := client.DNSRecords(ctx, zoneID, txtRecord)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 
 	aRecord := cloudflare.DNSRecord{Name: fqdn, Type: "A"}
 	aRecords, err := client.DNSRecords(ctx, zoneID, aRecord)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 
@@ -317,8 +299,7 @@ func deleteRecord(ctx context.Context, client *cloudflare.API, zone string, fqdn
 	for _, record := range records {
 		err := client.DeleteDNSRecord(ctx, zoneID, record.ID)
 		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			metrics.ExecErrInc(msg)
+			metrics.ExecErrInc(err.Error())
 			return false, err
 		}
 		logger.Info("Deleted DNS record", "zone", zone, "record", record.Name, "type", record.Type)
@@ -346,8 +327,7 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 	// Get ZoneID
 	zoneID, err := client.ZoneIDByName(zone)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 
@@ -361,8 +341,7 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 	logger.Info("trying to add record", "zone", zone, "name", txtRecordName, "type", "TXT")
 	txtRecord, err := client.CreateDNSRecord(ctx, zoneID, txtRecordRequest)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 	logger.Info("Added DNS record", "zone", zone, "name", sName, "type", "TXT", "success", txtRecord.Success)
@@ -377,8 +356,7 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 	logger.Info("trying to add record", "zone", zone, "name", sName, "type", "A")
 	aRecord, err := client.CreateDNSRecord(ctx, zoneID, aRecordRequest)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 	logger.Info("Added record", "zone", zone, "name", sName, "type", "A", "success", aRecord.Success)
@@ -391,16 +369,14 @@ func getAllRecords(ctx context.Context, client *cloudflare.API, zone string) (fl
 	// Get ZoneID
 	zoneID, err := client.ZoneIDByName(zone)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return 0.0, err
 	}
 
 	record := cloudflare.DNSRecord{}
 	records, err := client.DNSRecords(ctx, zoneID, record)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return 0.0, err
 	}
 	return float64(len(records)), err

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -40,14 +40,15 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 	recordType := "TXT"
 
 	// Count all records in the zone. Useful for alerting purposes.
-	// This call is pretty expensive ~50s for 3k records, run in a goroutine.
+	// This call is expensive. Takes up to ~50s for 3k records. Run in a Goroutine.
 	go func() {
 		allRecords, err := getAllRecords(context.TODO(), client, cfg.Zone)
 		if err != nil {
 			metrics.ExecErrInc(err.Error())
 			logger.Error("Error occured while fetching all records", "provider", cfg.Provider, "zone", cfg.Zone, "error", err.Error())
+		} else {
+			metrics.DNSRecordsTotal(cfg.Provider, allRecords)
 		}
-		metrics.DNSRecordsTotal(cfg.Provider, allRecords)
 	}()
 
 	// Fetch all TXT DNS

--- a/pkg/providers/digitalocean/dnsrecord.go
+++ b/pkg/providers/digitalocean/dnsrecord.go
@@ -37,10 +37,8 @@ func (d DigitalOceanDNS) Sync(nodes []Node) {
 	// Fetch all TXT DNS
 	txtRecords, err := getRecords(context.TODO(), client, cfg.Zone, recordType)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
-		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain)
-		logger.Info(err.Error())
+		metrics.ExecErrInc(err.Error())
+		logger.Error("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 		return
 	}
 
@@ -76,9 +74,8 @@ func (d DigitalOceanDNS) Sync(nodes []Node) {
 			} else {
 				_, err := addRecord(context.TODO(), client, cfg.Zone, name, cfg.Subdomain, addressIPv4, "", "", cfg.Env)
 				if err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while adding records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 				}
 			}
 		}
@@ -93,9 +90,8 @@ func (d DigitalOceanDNS) Sync(nodes []Node) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				msg := fmt.Sprintf("%v", err)
-				metrics.ExecErrInc(msg)
-				logger.Info(err.Error())
+				metrics.ExecErrInc(err.Error())
+				logger.Error("Error occured while deleting records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 			}
 		}
 	}
@@ -123,10 +119,8 @@ func (c DigitalOceanDNS) SyncPods(pods []Pod) {
 	// Fetch all TXT DNS
 	txtRecords, err := getRecords(context.TODO(), client, cfg.Zone, recordType)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
-		logger.Info("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain)
-		logger.Info(err.Error())
+		metrics.ExecErrInc(err.Error())
+		logger.Error("Error occured while fetching records", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 		return
 	}
 
@@ -169,9 +163,8 @@ func (c DigitalOceanDNS) SyncPods(pods []Pod) {
 				txtRecordName := podName
 				_, err := addRecord(context.TODO(), client, cfg.Zone, podName, cfg.Subdomain, addressIPv4, txtRecordName, txtLabel, cfg.Env)
 				if err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while adding record", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 				}
 			}
 		}
@@ -189,9 +182,8 @@ func (c DigitalOceanDNS) SyncPods(pods []Pod) {
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {
-				msg := fmt.Sprintf("%v", err)
-				metrics.ExecErrInc(msg)
-				logger.Info(err.Error())
+				metrics.ExecErrInc(err.Error())
+				logger.Error("Error occured while deleting record", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 			}
 		}
 	}
@@ -214,15 +206,13 @@ func (c DigitalOceanDNS) SyncPods(pods []Pod) {
 				logger.Debug("Launching deletion", "record", cName)
 				_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 				if err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while deleting record", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 				}
 				_, _err := addRecord(context.TODO(), client, cfg.Zone, podName, cfg.Subdomain, addressIPv4, podName, txtLabel, cfg.Env)
 				if _err != nil {
-					msg := fmt.Sprintf("%v", err)
-					metrics.ExecErrInc(msg)
-					logger.Info(err.Error())
+					metrics.ExecErrInc(err.Error())
+					logger.Error("Error occured while adding record", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
 				}
 			}
 		}
@@ -241,8 +231,7 @@ func getRecords(ctx context.Context, client *godo.Client, domain string, recordT
 	for {
 		rr, _, err := client.Domains.RecordsByType(ctx, domain, recordType, opt)
 		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			metrics.ExecErrInc(msg)
+			metrics.ExecErrInc(err.Error())
 			return records, err
 		}
 
@@ -264,15 +253,13 @@ func deleteRecord(ctx context.Context, client *godo.Client, zone string, name st
 
 	txtRecords, _, err := client.Domains.RecordsByTypeAndName(ctx, zone, "TXT", name, opt)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 
 	aRecords, _, err := client.Domains.RecordsByTypeAndName(ctx, zone, "A", name, opt)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 
@@ -282,8 +269,7 @@ func deleteRecord(ctx context.Context, client *godo.Client, zone string, name st
 		logger.Debug("Deleting", "record", record)
 		response, err := client.Domains.DeleteRecord(ctx, zone, record.ID)
 		if err != nil {
-			msg := fmt.Sprintf("%v", err)
-			metrics.ExecErrInc(msg)
+			metrics.ExecErrInc(err.Error())
 			return false, err
 		}
 		logger.Info("Deleted DNS record", "zone", zone, "record", record.Name, "type", record.Type, "responseStatus", response.Status)
@@ -316,16 +302,14 @@ func addRecord(ctx context.Context, client *godo.Client, zone string, name strin
 
 	_, aRecordResponse, err := client.Domains.CreateRecord(ctx, zone, aRecordRequest)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 	logger.Info("Added record", "zone", zone, "name", name, "type", "A", "responseStatus", aRecordResponse.Status)
 
 	_, txtRecordResponse, err := client.Domains.CreateRecord(ctx, zone, txtRecordRequest)
 	if err != nil {
-		msg := fmt.Sprintf("%v", err)
-		metrics.ExecErrInc(msg)
+		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
 	logger.Info("Added DNS record", "zone", zone, "name", name, "type", "TXT", "responseStatus", txtRecordResponse.Status)


### PR DESCRIPTION
This PR introduces the following changes:

## Error log level
Using `Info` and `Debug` served us well so far, however introducing `Error` makes some systems (e.g. Grafana) separate errors from info or debug logs. Then things like alerting, highlighting, etc. become easier.

## Unblock go routine
When the execution hits the return statement, hangs. We don't want that, we prefer to keep running or die. I haven't thought this through thoroughly, this is mostly hunch: removing the return statement, the routine should continue the execution just fine and exit cleanly.