### PR TITLE
refactor: Don't print messages when not needed

### DIFF
--- a/pkg/providers/digitalocean/dnsrecord.go
+++ b/pkg/providers/digitalocean/dnsrecord.go
@@ -59,8 +59,8 @@ func (d DigitalOceanDNS) Sync(nodes []Node) {
 
 	// Find new entries
 	addEntries := common.Compare(nodeHostnames, dnsRecords)
-	logger.Info("Entries to be added", "entries", addEntries)
 	if len(addEntries) > 0 {
+		logger.Info("Entries to be added", "entries", addEntries)
 		for _, name := range addEntries {
 			addressIPv4 := ""
 			// this loop seems a bit inefficient at first glance


### PR DESCRIPTION
The `digitalocean` provider prints messages like:

```
2021-12-03 08:20:13 time="2021-12-03T06:20:13Z" level=info msg="Entries to be added" entries="[]"
```

on every run. There's no need to populate the logging system when
`entries` slice is empty.