### PR TITLE
feat: Switch to Doppler for secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,7 @@ commands:
             - ZONE: <<parameters.zone>>
             - LOGLEVEL: <<parameters.level>>
           command: |
-            mkdir ~/.secrethub
-            echo ${SECRETHUB_CREDENTIAL} > ~/.secrethub/credential
-            curl -LO https://github.com/secrethub/secrethub-cli/releases/download/v0.41.2/secrethub-v0.41.2-linux-amd64.tar.gz
-            tar zxvf secrethub-v0.41.2-linux-amd64.tar.gz -C /tmp
-            mkdir -p deployments/base/secrets deployments/overlays/cluster/secrets
-            /tmp/bin/secrethub read -n gather/gather-town/deploy/terraform/dockerhub_credentials > deployments/base/secrets/priv-docker-registry
-            /tmp/bin/secrethub read -n gather/gather-town/deploy/terraform/<<parameters.token>>  > deployments/overlays/cluster/secrets/TOKEN
+            sed -i "s/__KUSTOMIZE_DOCKERHUB_CREDENTIALS__/$(echo -n ${DOCKERHUB_CREDENTIALS} | base64 -w0)/g" deployments/base/docker-registry.yaml
             cd deployments/overlays/cluster
             kustomize edit set image << parameters.image >>:${CIRCLE_SHA1:0:9}
             envsubst < deployment.yaml > deployment-temp.yaml

--- a/deployments/base/casper-3-environment.yaml
+++ b/deployments/base/casper-3-environment.yaml
@@ -1,0 +1,12 @@
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: casper-3-environment-secrets # DopplerSecret Name
+  namespace: infrastructure
+spec:
+  tokenSecret: # Kubernetes service token secret (namespace defaults to doppler-operator-system)
+    name: doppler-gather-town-casper-3-circleci-token
+    namespace: doppler-operator-system
+  managedSecret: # Kubernetes managed secret (will be created if does not exist)
+    name: casper-3-environment
+    namespace: __KUSTOMIZE_NAMESPACE__ # Should match the namespace of deployments that will use the secret

--- a/deployments/base/docker-registry.yaml
+++ b/deployments/base/docker-registry.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+metadata:
+  name: priv-docker-registry
+data:
+  .dockerconfigjson: __KUSTOMIZE_DOCKERHUB_CREDENTIALS__
+kind: Secret
+type: kubernetes.io/dockerconfigjson

--- a/deployments/base/kustomization.yaml
+++ b/deployments/base/kustomization.yaml
@@ -12,9 +12,5 @@ resources:
 - service.yaml
 - serviceaccount.yaml
 - servicemonitor.yaml
-
-secretGenerator:
-  - name: priv-docker-registry
-    files:
-      - .dockerconfigjson=secrets/priv-docker-registry
-    type: kubernetes.io/dockerconfigjson
+- docker-registry.yaml
+- casper-3-environment.yaml

--- a/deployments/overlays/cluster/deployment.yaml
+++ b/deployments/overlays/cluster/deployment.yaml
@@ -10,7 +10,7 @@ spec:
           image: gathertown/casper-3:6392065
           envFrom:
             - secretRef:
-                name: token
+                name: casper-3-environment
           env:
             - name: ENV
               value: ${ENV}

--- a/deployments/overlays/cluster/kustomization.yaml
+++ b/deployments/overlays/cluster/kustomization.yaml
@@ -11,12 +11,6 @@ images:
 patchesStrategicMerge:
 - deployment.yaml
 
-secretGenerator:
-- files:
-  - secrets/TOKEN
-  name: token
-  namespace: infrastructure
-
 resources:
 - ../../base/
 - prometheusrules.yaml


### PR DESCRIPTION
Switch to Doppler for fetching the secrets. For that, we are making
use of the DopplerSecret CRD. We are also making use of the
DOCKERHUB_CREDENTIALS project variable to provision the docker-registry
kubernetes secret.
