### PR TITLE
fix: Drop __KUSTOMIZE_NAMESPACE__ variable

### DIFF
--- a/deployments/base/casper-3-environment.yaml
+++ b/deployments/base/casper-3-environment.yaml
@@ -9,4 +9,4 @@ spec:
     namespace: doppler-operator-system
   managedSecret: # Kubernetes managed secret (will be created if does not exist)
     name: casper-3-environment
-    namespace: __KUSTOMIZE_NAMESPACE__ # Should match the namespace of deployments that will use the secret
+    namespace: infrastructure # Should match the namespace of deployments that will use the secret


### PR DESCRIPTION
The namespace is always 'infrastructure' so lets drop the variable
since we never really replaced it.
