### PR TITLE
feat: Print IP address information for A records

### DIFF
--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -359,7 +359,7 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
-	logger.Info("Added record", "zone", zone, "name", sName, "type", "A", "success", aRecord.Success)
+	logger.Info("Added record", "zone", zone, "name", sName, "type", "A", "success", aRecord.Success, "content", addressIPv4)
 
 	return true, err
 }


### PR DESCRIPTION
Sometimes it's helpful to have the content of the A record that was
created in the logs in order to be able to quickly search for a
particular host or IP address in the logs to obtain more information
during debugging.
