### PR TITLE
Switch the `dev` environment to cloudflare provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ workflows:
           environment: development
           token: TF_VAR_do_token
           cluster: $K8S_DEV_NYC1
-          provider: digitalocean
+          provider: cloudflare
           subdomain: dev
           zone: k8s.gather.town
           level: info


### PR DESCRIPTION
We switched to CloudFlare for the development environment. Switching
`casper-3` to use CloudFlare for the development environment.