### PR TITLE
main: Prevent execution when there are errors talking to API

### DIFF
--- a/cmd/casper-3/main.go
+++ b/cmd/casper-3/main.go
@@ -53,11 +53,17 @@ func main() {
 		c, err := kubernetes.New()
 		if err != nil {
 			logger.Error("Error occured while initializing pods", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
+			// Wait before we continue to next iteration
+			time.Sleep(time.Duration(interval) * time.Second)
+			continue
 		}
 
 		n, err := c.Nodes()
 		if err != nil {
 			logger.Error("Error occured while fetching kubernetes nodes info", "provider", cfg.Provider, "zone", cfg.Zone, "host", cfg.Subdomain, "error", err.Error())
+			// Wait before we continue to next iteration
+			time.Sleep(time.Duration(interval) * time.Second)
+			continue
 		}
 
 		p.Sync(n)


### PR DESCRIPTION
If we encounter an error when talking to Kubernetes API we need to terminate
the current iteration instead of proceeding with (possibly?) and empty
slice of hosts as that would result in actually removing all entries for
them.
