### PR TITLE
feat: Compare record & node prefixes before deletion

### DIFF
--- a/pkg/common.go
+++ b/pkg/common.go
@@ -1,5 +1,10 @@
 package common
 
+import (
+	"fmt"
+	"strings"
+)
+
 // shared structures
 type Node struct {
 	Name       string
@@ -30,4 +35,16 @@ func Compare(a, b []string) []string {
 	}
 
 	return diff
+}
+
+// Checks if a recordName follows the prefix pattern that k8s nodes have
+func RecordPrefixMatchesNodePrefixes(recordName string, nodeNames []string) bool {
+	for _, node := range nodeNames {
+		nodePrefix := strings.Split(node, "-")[0]
+		prefix := fmt.Sprintf("%s-", nodePrefix)
+		if strings.HasPrefix(recordName, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/common_test.go
+++ b/pkg/common_test.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"testing"
+)
+
+type recordPrefixMatchesNodePrefixesTest struct {
+	recordName string
+	nodeNames  []string
+	expected   bool
+}
+
+var recordPrefixMatchesNodePrefixesTestCases = []recordPrefixMatchesNodePrefixesTest{
+	{
+		"sfu-123.gather.town",
+		[]string{"sfu-123-313"},
+		true,
+	},
+	{
+		"sfu-123.gather.town",
+		[]string{"sfu-abc", "ip-1-2-3"},
+		true,
+	},
+	{
+		"sfu-123.gather.town",
+		[]string{"xyz-"},
+		false,
+	},
+}
+
+func TestRecordPrefixMatchesNodePrefixes(t *testing.T) {
+	for _, test := range recordPrefixMatchesNodePrefixesTestCases {
+		if output := RecordPrefixMatchesNodePrefixes(test.recordName, test.nodeNames); output != test.expected {
+			t.Errorf("Output for test %v is not equal to expected %v", test, test.expected)
+		}
+	}
+}

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -110,6 +110,10 @@ func (d CloudFlareDNS) Sync(nodes []Node) {
 			if cfg.Subdomain != "" {
 				cName = fmt.Sprintf("%s.%s.%s", name, cfg.Subdomain, cfg.Zone)
 			}
+			if isRecordSafeForDeletion := common.RecordPrefixMatchesNodePrefixes(cName, nodeHostnames); !isRecordSafeForDeletion {
+				logger.Info("Casper-3 wants to delete this record", "record", cName, "Skipping..")
+				continue
+			}
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {

--- a/pkg/providers/digitalocean/dnsrecord.go
+++ b/pkg/providers/digitalocean/dnsrecord.go
@@ -87,6 +87,10 @@ func (d DigitalOceanDNS) Sync(nodes []Node) {
 		for _, name := range deleteEntries {
 			// The 'Name' entry is the FQDN
 			cName := fmt.Sprintf("%s.%s.%s", name, cfg.Subdomain, cfg.Zone)
+			if isRecordSafeForDeletion := common.RecordPrefixMatchesNodePrefixes(cName, nodeHostnames); !isRecordSafeForDeletion {
+				logger.Info("Casper-3 wants to delete this record", "record", cName, "Skipping..")
+				continue
+			}
 			logger.Debug("Launching deletion", "record", cName)
 			_, err := deleteRecord(context.TODO(), client, cfg.Zone, cName)
 			if err != nil {


### PR DESCRIPTION
## Description

   feat:Compare record & node prefixes before deletion

    This commit introduces a common function `RecordPrefixMatchesNodePrefixes`
    that aims to check if there is a match between record and node
    prefixes. Casper-3 should be allowed to delete only records that
    are prefixed with the labeled k8s node prefixes too. Let's add this
    check as a safeguard here, in order to avoid the deletion of unwilling
    records.