### PR TITLE
feat: Add ability to create proxied cloudflare records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ commands:
       level:
         type: string
         default: "info"
+      cloudflare_proxied:
+        type: boolean
+        default: false
     steps:
       - checkout
       - kubernetes/install-kubectl
@@ -76,6 +79,7 @@ commands:
             - SUBDOMAIN: <<parameters.subdomain>>
             - ZONE: <<parameters.zone>>
             - LOGLEVEL: <<parameters.level>>
+            - CLOUDFLARE_PROXIED: <<parameters.cloudflare_proxied>>
           command: |
             sed -i "s/__KUSTOMIZE_DOCKERHUB_CREDENTIALS__/$(echo -n ${DOCKERHUB_CREDENTIALS} | base64 -w0)/g" deployments/base/docker-registry.yaml
             cd deployments/overlays/cluster
@@ -141,6 +145,8 @@ jobs:
         default: "us-east-1"
       level:
         type: string
+      cloudflare_proxied:
+        type: boolean
     executor: docker/docker
     steps:
       - setup_remote_docker:
@@ -154,6 +160,7 @@ jobs:
           level: <<parameters.level>>
           region: <<parameters.region>>
           cloud_provider: <<parameters.cloud_provider>>
+          cloudflare_proxied: <<parameters.cloudflare_proxied>>
 
 workflows:
   build-and-push:
@@ -178,6 +185,7 @@ workflows:
           subdomain: dev.k8s
           zone: gather.town
           level: debug
+          cloudflare_proxied: true
           filters:
             branches:
               only:
@@ -194,6 +202,7 @@ workflows:
           subdomain: nyc3-a.stg.do
           zone: gather.town
           level: debug
+          cloudflare_proxied: false
           filters:
             branches:
               only:
@@ -216,6 +225,7 @@ workflows:
           subdomain: blr1-a.prod.do
           zone: gather.town
           level: info
+          cloudflare_proxied: false
           filters:
             branches:
               only:

--- a/deployments/overlays/cluster/deployment.yaml
+++ b/deployments/overlays/cluster/deployment.yaml
@@ -22,3 +22,5 @@ spec:
               value: ${SUBDOMAIN}
             - name: ZONE
               value: ${ZONE}
+            - name: CLOUDFLARE_PROXIED
+              value: ${CLOUDFLARE_PROXIED}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ const (
 	defaultAllowSyncPods       = "false"
 	defaultSyncPodLabelKey     = "casper-3.gather.town/sync"
 	defaultSyncPodLabelValue   = "true"
+	defaultCloudFlareProxied   = "false"
 )
 
 // Config contains service information that can be changed from the
@@ -36,6 +37,7 @@ type Config struct {
 	AllowSyncPods       string
 	SyncPodLabelKey     string
 	SyncPodLabelValue   string
+	CloudFlareProxied   string
 }
 
 // FromEnv returns the service configuration from the environment variables.
@@ -54,6 +56,7 @@ func FromEnv() *Config {
 		allowSyncPods       = getenv("ALLOW_SYNC_PODS", defaultAllowSyncPods)
 		syncPodLabelKey     = getenv("SYNC_POD_LABEL_KEY", defaultSyncPodLabelKey)
 		syncPodLabelValue   = getenv("SYNC_POD_LABEL_VALUE", defaultSyncPodLabelValue)
+		cloudFlareProxied   = getenv("CLOUDFLARE_PROXIED", defaultCloudFlareProxied)
 	)
 
 	c := &Config{
@@ -69,6 +72,7 @@ func FromEnv() *Config {
 		AllowSyncPods:       allowSyncPods,
 		SyncPodLabelKey:     syncPodLabelKey,
 		SyncPodLabelValue:   syncPodLabelValue,
+		CloudFlareProxied:   cloudFlareProxied,
 	}
 	return c
 }

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -344,13 +345,21 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
-	logger.Info("Added DNS record", "zone", zone, "name", sName, "type", "TXT", "success", txtRecord.Success)
+
+	proxied, err := strconv.ParseBool(cfg.CloudFlareProxied)
+	if err != nil {
+		metrics.ExecErrInc(err.Error())
+		return false, err
+	}
+
+	logger.Info("Added DNS record", "zone", zone, "name", sName, "type", "TXT", "success", txtRecord.Success, "proxied", proxied)
 
 	aRecordRequest := cloudflare.DNSRecord{
 		Type:    "A",
 		Name:    sName,
 		Content: addressIPv4,
 		TTL:     1800,
+		Proxied: &proxied,
 	}
 
 	logger.Info("trying to add record", "zone", zone, "name", sName, "type", "A")


### PR DESCRIPTION
Add ability to create proxied cloudflare records. This is being
controlled by the CLOUDFLARE_PROXIED env variable and it's turn on
by default on development environment.
