### PR TITLE
Add missing quotes for boolean values

### DIFF
--- a/deployments/overlays/cluster/deployment.yaml
+++ b/deployments/overlays/cluster/deployment.yaml
@@ -23,4 +23,4 @@ spec:
             - name: ZONE
               value: ${ZONE}
             - name: CLOUDFLARE_PROXIED
-              value: ${CLOUDFLARE_PROXIED}
+              value: "${CLOUDFLARE_PROXIED}"

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -356,7 +356,7 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 		return false, err
 	}
 
-	logger.Info("Added DNS record", "zone", zone, "name", sName, "type", "TXT", "success", txtRecord.Success, "proxied", proxied)
+	logger.Info("Added DNS record", "zone", zone, "name", sName, "type", "TXT", "success", txtRecord.Success)
 
 	aRecordRequest := cloudflare.DNSRecord{
 		Type:    "A",
@@ -372,7 +372,7 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 		metrics.ExecErrInc(err.Error())
 		return false, err
 	}
-	logger.Info("Added record", "zone", zone, "name", sName, "type", "A", "success", aRecord.Success, "content", addressIPv4)
+	logger.Info("Added record", "zone", zone, "name", sName, "type", "A", "success", aRecord.Success, "content", addressIPv4, "proxied", proxied)
 
 	return true, err
 }


### PR DESCRIPTION
We are seeing the following problem during deployment
```
cannot convert int64 to string
```

Apparently boolean in circleci is being passed as '1' or '0' so
lets add the missing quotes.

Finally, fix the logging of proxied records as it was previously done
on the TXT type instead of the A one.