### PR TITLE
feat: add casper 3 support for gs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ commands:
       cloudflare_proxied:
         type: boolean
         default: false
+      label_values:
+        type: string
+        default: "sfu"
     steps:
       - checkout
       - kubernetes/install-kubectl
@@ -80,6 +83,7 @@ commands:
             - ZONE: <<parameters.zone>>
             - LOGLEVEL: <<parameters.level>>
             - CLOUDFLARE_PROXIED: <<parameters.cloudflare_proxied>>
+            - LABEL_VALUES: <<parameters.label_values>>
           command: |
             sed -i "s/__KUSTOMIZE_DOCKERHUB_CREDENTIALS__/$(echo -n ${DOCKERHUB_CREDENTIALS} | base64 -w0)/g" deployments/base/docker-registry.yaml
             cd deployments/overlays/cluster
@@ -147,6 +151,8 @@ jobs:
         type: string
       cloudflare_proxied:
         type: boolean
+      label_values:
+        type: string
     executor: docker/docker
     steps:
       - setup_remote_docker:
@@ -161,6 +167,7 @@ jobs:
           region: <<parameters.region>>
           cloud_provider: <<parameters.cloud_provider>>
           cloudflare_proxied: <<parameters.cloudflare_proxied>>
+          label_values: <<parameters.label_values>>
 
 workflows:
   build-and-push:
@@ -186,6 +193,7 @@ workflows:
           zone: gather.town
           level: debug
           cloudflare_proxied: true
+          label_values: "sfu, gameserver"
           filters:
             branches:
               only:
@@ -203,6 +211,7 @@ workflows:
           zone: gather.town
           level: debug
           cloudflare_proxied: true
+          label_values: "sfu"
           filters:
             branches:
               only:
@@ -226,6 +235,7 @@ workflows:
           zone: gather.town
           level: info
           cloudflare_proxied: false
+          label_values: "sfu"
           filters:
             branches:
               only:

--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -27,8 +27,6 @@ spec:
               value: "60"
             - name: LABEL_KEY
               value: doks.digitalocean.com/node-pool
-            - name: LABEL_VALUES
-              value: "sfu"
             - name: ALLOW_SYNC_PODS
               value: "false"
           resources:

--- a/deployments/overlays/cluster/deployment.yaml
+++ b/deployments/overlays/cluster/deployment.yaml
@@ -24,3 +24,5 @@ spec:
               value: ${ZONE}
             - name: CLOUDFLARE_PROXIED
               value: "${CLOUDFLARE_PROXIED}"
+            - name: LABEL_VALUES
+              value: "${LABEL_VALUES}"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"os"
+	"strings"
 )
 
 const (
@@ -63,7 +64,7 @@ func FromEnv() *Config {
 		Env:                 env,
 		ScanIntervalSeconds: scanIntervalSeconds,
 		LabelKey:            labelKey,
-		LabelValues:         labelValues,
+		LabelValues:         splitAndRejoin(labelValues, ","),
 		Provider:            provider,
 		Token:               token,
 		Subdomain:           subdomain,
@@ -83,4 +84,19 @@ func getenv(key, fallback string) string {
 		return fallback
 	}
 	return v
+}
+
+// splitAndRejoin splits a string with a given seperator
+// and then join it back, with all the extraneous space and
+// trailing seperators removed
+func splitAndRejoin(str string, sep string) string {
+	parsed := []string{}
+	for _, v := range strings.Split(str, sep) {
+		val := strings.TrimSpace(v)
+		if val == "" {
+			continue
+		}
+		parsed = append(parsed, val)
+	}
+	return strings.Join(parsed, ", ")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -72,4 +73,33 @@ func TestFromEnv(t *testing.T) {
 	unsetenv(t, "TOKEN")
 	unsetenv(t, "SUBDOMAIN")
 	unsetenv(t, "ZONE")
+}
+
+func TestSplitAndRejoin(t *testing.T) {
+	type test struct {
+		input string
+		sep   string
+		want  string
+	}
+
+	tests := []test{
+		{input: "sfu,gameserver", sep: ",", want: "sfu, gameserver"},
+		{input: "sfu, gameserver", sep: ",", want: "sfu, gameserver"},
+		{input: "sfu, ,gameserver", sep: ",", want: "sfu, gameserver"},
+		{input: "sfu,,,gameserver", sep: ",", want: "sfu, gameserver"},
+		{input: "sfu,gameserver  ", sep: ",", want: "sfu, gameserver"},
+		{input: "  sfu  ,  gameserver  ", sep: ",", want: "sfu, gameserver"},
+		{input: " sfu,", sep: ",", want: "sfu"},
+		{input: "sfu", sep: ",", want: "sfu"},
+		{input: " sfu ", sep: ",", want: "sfu"},
+		{input: "", sep: ",", want: ""},
+		{input: ",", sep: ",", want: ""},
+	}
+
+	for _, tc := range tests {
+		got := splitAndRejoin(tc.input, tc.sep)
+		if !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
 }


### PR DESCRIPTION
This PR adds support for gameserver nodes in `casper-3`. We already had support for handling multiple node labels while building `labelSelector` in `GetNodes`. The only thing left was to make sure that `LabelValues` env variable is properly formatted for use as a [set based label requirement](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement)