### PR TITLE
[circleci] Force kubectl 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ commands:
         default: "sfu"
     steps:
       - checkout
-      - kubernetes/install-kubectl
+      - kubernetes/install-kubectl:
+          kubectl-version: v1.21.11
       - envsbt/install
       - kuz/install:
           version: "v4.0.1"


### PR DESCRIPTION
We are hitting https://github.com/CircleCI-Public/aws-eks-orb/issues/67
so lets hardcode the version of kubectl that we install to match
the one that we have in our k8s clusters.
