### PR TITLE
feat: Adjust casper-3 limits

### DIFF
--- a/deployments/base/deployment.yaml
+++ b/deployments/base/deployment.yaml
@@ -31,8 +31,11 @@ spec:
               value: "false"
           resources:
             limits:
-              cpu: 1000m
-              memory: 300Mi
+              cpu: 75m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 48Mi
           securityContext:
             runAsUser: 5003
             runAsNonRoot: true


### PR DESCRIPTION
Adjust casper-3 limits and requests to make space for other pods, in this case falco-IDS. Although we do not define `requests`, kubernetes will use the `limits` to set `requests` as well.

Casper-3 uses very low vCPU (max is 75m according to Prometheus in sgp-1b) and memory rarely goes above 32MB.

Use these as requests and keep the limits close as we don't see spikes in a 14d span.