### PR TITLE
[INFRA-529]chore: Drop Cloudflare proxy for GKE records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ workflows:
           environment: staging-gke-poc
           cluster: gather-gke-poc
           subdomain: eu-west8.stg.gke
+          cloudflare_proxied: false
           cloud_provider: "GoogleComputePlatform"
 
       # production clusters


### PR DESCRIPTION
We do not have an edge certificate for the GKE POC cluster so proxying
that through cloudflare results to certificate problems. Lets drop it.
