### PR TITLE
Niksrc/infra 508 add casper 3 support for gs 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ commands:
       level:
         type: string
         default: "info"
-      cloudflare_proxied:
-        type: boolean
-        default: false
+      cloudflare_proxied_node_pools:
+        type: string
+        default: ""
       label_values:
         type: string
         default: "sfu"
@@ -92,7 +92,7 @@ commands:
             - SUBDOMAIN: <<parameters.subdomain>>
             - ZONE: <<parameters.zone>>
             - LOGLEVEL: <<parameters.level>>
-            - CLOUDFLARE_PROXIED: <<parameters.cloudflare_proxied>>
+            - CLOUDFLARE_PROXIED_NODE_POOLS: <<parameters.cloudflare_proxied_node_pools>>
             - LABEL_VALUES: <<parameters.label_values>>
           command: |
             sed -i "s/__KUSTOMIZE_DOCKERHUB_CREDENTIALS__/$(echo -n ${DOCKERHUB_CREDENTIALS} | base64 -w0)/g" deployments/base/docker-registry.yaml
@@ -157,8 +157,8 @@ jobs:
         default: "us-east-1"
       level:
         type: string
-      cloudflare_proxied:
-        type: boolean
+      cloudflare_proxied_node_pools:
+        type: string
       label_values:
         type: string
     executor: docker/docker
@@ -173,7 +173,7 @@ jobs:
           level: <<parameters.level>>
           region: <<parameters.region>>
           cloud_provider: <<parameters.cloud_provider>>
-          cloudflare_proxied: <<parameters.cloudflare_proxied>>
+          cloudflare_proxied_node_pools: <<parameters.cloudflare_proxied_node_pools>>
           label_values: <<parameters.label_values>>
 
 workflows:
@@ -198,7 +198,7 @@ workflows:
           subdomain: dev.k8s
           zone: gather.town
           level: debug
-          cloudflare_proxied: true
+          cloudflare_proxied_node_pools: "sfu, engine"
           label_values: "sfu, engine"
           filters:
             branches:
@@ -215,7 +215,7 @@ workflows:
           subdomain: nyc3-a.stg.do
           zone: gather.town
           level: debug
-          cloudflare_proxied: true
+          cloudflare_proxied_node_pools: "sfu, engine"
           label_values: "sfu, engine"
           filters:
             branches:
@@ -234,7 +234,7 @@ workflows:
           environment: staging-gke-poc
           cluster: gather-gke-poc
           subdomain: eu-west8.stg.gke
-          cloudflare_proxied: false
+          cloudflare_proxied_node_pools: ""
           cloud_provider: "GoogleComputePlatform"
 
       # production clusters
@@ -247,7 +247,7 @@ workflows:
           subdomain: blr1-a.prod.do
           zone: gather.town
           level: info
-          cloudflare_proxied: true
+          cloudflare_proxied_node_pools: "sfu, engine"
           label_values: "sfu"
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ workflows:
           subdomain: dev.k8s
           zone: gather.town
           level: debug
-          cloudflare_proxied_node_pools: "sfu, engine"
+          cloudflare_proxied_node_pools: "sfu"
           label_values: "sfu, engine"
           filters:
             branches:
@@ -215,7 +215,7 @@ workflows:
           subdomain: nyc3-a.stg.do
           zone: gather.town
           level: debug
-          cloudflare_proxied_node_pools: "sfu, engine"
+          cloudflare_proxied_node_pools: "sfu"
           label_values: "sfu, engine"
           filters:
             branches:
@@ -247,7 +247,7 @@ workflows:
           subdomain: blr1-a.prod.do
           zone: gather.town
           level: info
-          cloudflare_proxied_node_pools: "sfu, engine"
+          cloudflare_proxied_node_pools: "sfu"
           label_values: "sfu"
           filters:
             branches:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,72 +8,72 @@ import (
 )
 
 const (
-	defaultEnv                 = "development"
-	defaultLabelKey            = "doks.digitalocean.com/node-pool"
-	defaultLabelValues         = "sfu"
-	defaultProvider            = "digitalocean"
-	defaultScanIntervalSeconds = "60"
-	defaultToken               = "abcd123"
-	defaultZone                = "k8s.gather.town"
-	defaultSubdomain           = ""     // effective only for DigitalOcean provider
-	defaultLogLevel            = "info" // use to "debug" for debug level, everything else is INFO
-	defaultAllowSyncPods       = "false"
-	defaultSyncPodLabelKey     = "casper-3.gather.town/sync"
-	defaultSyncPodLabelValue   = "true"
-	defaultCloudFlareProxied   = "false"
+	defaultEnv                        = "development"
+	defaultLabelKey                   = "doks.digitalocean.com/node-pool"
+	defaultLabelValues                = "sfu"
+	defaultProvider                   = "digitalocean"
+	defaultScanIntervalSeconds        = "60"
+	defaultToken                      = "abcd123"
+	defaultZone                       = "k8s.gather.town"
+	defaultSubdomain                  = ""     // effective only for DigitalOcean provider
+	defaultLogLevel                   = "info" // use to "debug" for debug level, everything else is INFO
+	defaultAllowSyncPods              = "false"
+	defaultSyncPodLabelKey            = "casper-3.gather.town/sync"
+	defaultSyncPodLabelValue          = "true"
+	defaultCloudFlareProxiedNodePools = ""
 )
 
 // Config contains service information that can be changed from the
 // environment.
 type Config struct {
-	Env                 string
-	LabelKey            string
-	LabelValues         string
-	Provider            string
-	ScanIntervalSeconds string
-	Token               string
-	Zone                string
-	Subdomain           string
-	LogLevel            string
-	AllowSyncPods       string
-	SyncPodLabelKey     string
-	SyncPodLabelValue   string
-	CloudFlareProxied   string
+	Env                        string
+	LabelKey                   string
+	LabelValues                string
+	Provider                   string
+	ScanIntervalSeconds        string
+	Token                      string
+	Zone                       string
+	Subdomain                  string
+	LogLevel                   string
+	AllowSyncPods              string
+	SyncPodLabelKey            string
+	SyncPodLabelValue          string
+	CloudflareProxiedNodePools []string
 }
 
 // FromEnv returns the service configuration from the environment variables.
 // If an environment variable is not found, then a default value is provided.
 func FromEnv() *Config {
 	var (
-		env                 = getenv("ENV", defaultEnv)
-		scanIntervalSeconds = getenv("INTERVAL", defaultScanIntervalSeconds)
-		labelKey            = getenv("LABEL_KEY", defaultLabelKey)
-		labelValues         = getenv("LABEL_VALUES", defaultLabelValues)
-		provider            = getenv("PROVIDER", defaultProvider)
-		token               = getenv("TOKEN", defaultToken)
-		subdomain           = getenv("SUBDOMAIN", defaultSubdomain)
-		zone                = getenv("ZONE", defaultZone)
-		logLevel            = getenv("LOGLEVEL", defaultLogLevel)
-		allowSyncPods       = getenv("ALLOW_SYNC_PODS", defaultAllowSyncPods)
-		syncPodLabelKey     = getenv("SYNC_POD_LABEL_KEY", defaultSyncPodLabelKey)
-		syncPodLabelValue   = getenv("SYNC_POD_LABEL_VALUE", defaultSyncPodLabelValue)
-		cloudFlareProxied   = getenv("CLOUDFLARE_PROXIED", defaultCloudFlareProxied)
+		env                        = getenv("ENV", defaultEnv)
+		scanIntervalSeconds        = getenv("INTERVAL", defaultScanIntervalSeconds)
+		labelKey                   = getenv("LABEL_KEY", defaultLabelKey)
+		labelValues                = getenv("LABEL_VALUES", defaultLabelValues)
+		provider                   = getenv("PROVIDER", defaultProvider)
+		token                      = getenv("TOKEN", defaultToken)
+		subdomain                  = getenv("SUBDOMAIN", defaultSubdomain)
+		zone                       = getenv("ZONE", defaultZone)
+		logLevel                   = getenv("LOGLEVEL", defaultLogLevel)
+		allowSyncPods              = getenv("ALLOW_SYNC_PODS", defaultAllowSyncPods)
+		syncPodLabelKey            = getenv("SYNC_POD_LABEL_KEY", defaultSyncPodLabelKey)
+		syncPodLabelValue          = getenv("SYNC_POD_LABEL_VALUE", defaultSyncPodLabelValue)
+		cloudflareProxiedNodePools = getenv("CLOUDFLARE_PROXIED_NODE_POOLS", defaultCloudFlareProxiedNodePools)
 	)
 
 	c := &Config{
-		Env:                 env,
-		ScanIntervalSeconds: scanIntervalSeconds,
-		LabelKey:            labelKey,
-		LabelValues:         splitAndRejoin(labelValues, ","),
-		Provider:            provider,
-		Token:               token,
-		Subdomain:           subdomain,
-		Zone:                zone,
-		LogLevel:            logLevel,
-		AllowSyncPods:       allowSyncPods,
-		SyncPodLabelKey:     syncPodLabelKey,
-		SyncPodLabelValue:   syncPodLabelValue,
-		CloudFlareProxied:   cloudFlareProxied,
+		Env:                        env,
+		ScanIntervalSeconds:        scanIntervalSeconds,
+		LabelKey:                   labelKey,
+		LabelValues:                splitAndRejoin(labelValues, ","),
+		Provider:                   provider,
+		Token:                      token,
+		Subdomain:                  subdomain,
+		Zone:                       zone,
+		LogLevel:                   logLevel,
+		AllowSyncPods:              allowSyncPods,
+		SyncPodLabelKey:            syncPodLabelKey,
+		SyncPodLabelValue:          syncPodLabelValue,
+		CloudflareProxiedNodePools: stringToList(cloudflareProxiedNodePools),
 	}
 	return c
 }
@@ -99,4 +99,11 @@ func splitAndRejoin(str string, sep string) string {
 		parsed = append(parsed, val)
 	}
 	return strings.Join(parsed, ", ")
+}
+
+// stringToList converts a `,` separated string into a
+// slice of strings
+func stringToList(str string) []string {
+	normalizedStr := splitAndRejoin(str, ",")
+	return strings.Split(normalizedStr, ", ")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,7 @@ func TestFromEnv(t *testing.T) {
 	setenv(t, "TOKEN", "abcd1231")
 	setenv(t, "SUBDOMAIN", "dev")
 	setenv(t, "ZONE", "k8s.gather.town")
+	setenv(t, "CLOUDFLARE_PROXIED_NODE_POOLS", "sfu, engine")
 
 	cfg := FromEnv()
 
@@ -63,6 +64,9 @@ func TestFromEnv(t *testing.T) {
 
 	if got, want := cfg.Zone, "k8s.gather.town"; got != want {
 		t.Errorf("FromEnv() 'ZONE' = %q; want %q", got, want)
+	}
+	if got, want := cfg.CloudflareProxiedNodePools, []string{"sfu", "engine"}; reflect.DeepEqual(want, got) == false {
+		t.Errorf("FromEnv() 'CLOUDFLARE_PROXIED_NODE_POOLS' = %q; want %q", got, want)
 	}
 
 	unsetenv(t, "ENV")

--- a/pkg/providers/cloudflare/dnsrecord.go
+++ b/pkg/providers/cloudflare/dnsrecord.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
@@ -361,10 +360,12 @@ func addRecord(ctx context.Context, client *cloudflare.API, zone string, subdoma
 		return false, err
 	}
 
-	proxied, err := strconv.ParseBool(cfg.CloudFlareProxied)
-	if err != nil {
-		metrics.ExecErrInc(err.Error())
-		return false, err
+	proxied := false
+	for _, p := range cfg.CloudflareProxiedNodePools {
+		if strings.HasPrefix(name, p) {
+			proxied = true
+			break
+		}
 	}
 
 	logger.Info("Added DNS record", "zone", zone, "name", sName, "type", "TXT", "success", txtRecord.Success)


### PR DESCRIPTION
# Description
This PR consists of two changes that are required as a part of reducing gameserver disconnections:
- feat: configure orange cloud per node pool
Adds support for enabling orange cloud per node pool by passing
a comma-separated list of node pools in `CLOUDFLARE_PROXIED_NODE_POOLS`
environment variable.
- disables orange cloud on engine node pool