### PR TITLE
fix: empty CLOUDFLARE_PROXY_POOLS broken parsing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,5 +105,8 @@ func splitAndRejoin(str string, sep string) string {
 // slice of strings
 func stringToList(str string) []string {
 	normalizedStr := splitAndRejoin(str, ",")
+	if normalizedStr == "" {
+		return []string{}
+	}
 	return strings.Split(normalizedStr, ", ")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -107,3 +107,32 @@ func TestSplitAndRejoin(t *testing.T) {
 		}
 	}
 }
+
+func TestStringToList(t *testing.T) {
+	type test struct {
+		input string
+		sep   string
+		want  []string
+	}
+
+	tests := []test{
+		{input: "sfu,engine", sep: ",", want: []string{"sfu", "engine"}},
+		{input: "sfu, engine", sep: ",", want: []string{"sfu", "engine"}},
+		{input: "sfu, ,engine", sep: ",", want: []string{"sfu", "engine"}},
+		{input: "sfu,,,engine", sep: ",", want: []string{"sfu", "engine"}},
+		{input: "sfu,engine  ", sep: ",", want: []string{"sfu", "engine"}},
+		{input: "  sfu  ,  engine  ", sep: ",", want: []string{"sfu", "engine"}},
+		{input: " sfu,", sep: ",", want: []string{"sfu"}},
+		{input: "sfu", sep: ",", want: []string{"sfu"}},
+		{input: " sfu ", sep: ",", want: []string{"sfu"}},
+		{input: "", sep: ",", want: []string{}},
+		{input: ",", sep: ",", want: []string{}},
+	}
+
+	for _, tc := range tests {
+		got := stringToList(tc.input)
+		if !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Split function in the `strings` package, `func Split(s, sep string) []string` has a behavior where
if s does not contain sep and sep is not empty, Split returns a slice of length 1 whose only element is s.
This breaks our expectation of having an empty node pool list in case the env variable is not set.

Handling this case explicitly fixes the issue.